### PR TITLE
Removed unnecessary print in check_for_database from amedata.py

### DIFF
--- a/barion/amedata.py
+++ b/barion/amedata.py
@@ -6,6 +6,7 @@ Barion
 Jul 2015 Xaratustrah
 Mar 2016 Xaratustrah
 Feb 2022 Xaratustrah
+Jun 2023 DFreireF
 
 """
 
@@ -13,7 +14,6 @@ import fortranformat as ff
 import urllib.request as ur
 import os
 import re
-
 
 class AMEData(object):
     """
@@ -101,11 +101,6 @@ class AMEData(object):
                 self.check_for_database()  # recursive call!
 
         else:
-            if self.ui_interface:
-                self.ui_interface.show_message(
-                    'AME Database files are available.')
-            else:
-                print('AME Database files are available.')
             self.init_ame_db()
             self.init_nubase_db()
 

--- a/barion/particle.py
+++ b/barion/particle.py
@@ -120,6 +120,7 @@ class Particle(object):
             if zz_min <= i[4] <= zz_max:
                 if nn_min <= i[3] <= nn_max:
                     for eee in range(ee_max):
+                        if eee == i[4]: break
                         # create particle
                         p = Particle(i[4], i[3], self.ame_data, self.ring)
                         p.qq = i[4] - eee


### PR DESCRIPTION
It can be very annoying getting the same message each time you call the class. Which would be once per particle (if you are using particle.py), so if you have 30 particles, you get the same message 30 times. I do not consider neither the message worth to be storaged in a log.